### PR TITLE
backend link replaced with the deployed render link and login button …

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -111,7 +111,7 @@ const Header = () => {
               <>
                 <Link to="/login">
                   <button className="bg-white py-2 px-6 rounded-[50px] text-primaryColor font-[600] h-[44px] flex items-center justify-center border border-primaryColor border-solid">
-                    Log In
+                    Log in
                   </button>
                 </Link>
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,2 @@
-export const BASE_URL = "http://localhost:8080/api";
+export const BASE_URL = "https://medibridge-backend.onrender.com/api";
 export const token = localStorage.getItem("token");


### PR DESCRIPTION
…updated, lower case i